### PR TITLE
Avaloniaのバージョン固定とReactiveUI.Avalonia追加

### DIFF
--- a/FLaunch2.Desktop/FLaunch2.Desktop.csproj
+++ b/FLaunch2.Desktop/FLaunch2.Desktop.csproj
@@ -18,7 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="11.3.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FLaunch2.Desktop/Program.cs
+++ b/FLaunch2.Desktop/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 using Avalonia;
-using Avalonia.ReactiveUI;
+using ReactiveUI.Avalonia;
 
 namespace FLaunch2.Desktop;
 

--- a/FLaunch2/FLaunch2.csproj
+++ b/FLaunch2/FLaunch2.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.11" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.11" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="11.3.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Avalonia関連NuGetパッケージのバージョン指定を$(AvaloniaVersion)から11.3.11に明示化し、ReactiveUI.Avalonia(11.3.8)を追加しました。また、Program.csのusingディレクティブもReactiveUI.Avaloniaに修正しました。