### PR TITLE
ボタンのテキストを中央揃えに統一

### DIFF
--- a/FLaunch2/Views/ConfirmWindow.axaml
+++ b/FLaunch2/Views/ConfirmWindow.axaml
@@ -11,8 +11,8 @@
   <Grid Margin="16" RowDefinitions="*,Auto">
 	<TextBlock Grid.Row="0" x:Name="MessageText" TextWrapping="Wrap" VerticalAlignment="Center"/>
 	<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-	  <Button x:Name="OkButton" Content="OK" Width="80" Click="OnOkClicked"/>
-	  <Button x:Name="CancelButton" Content="キャンセル" Width="80" Click="OnCancelClicked"/>
+	  <Button x:Name="OkButton" Content="OK" Width="80" Click="OnOkClicked" HorizontalContentAlignment="Center"/>
+	  <Button x:Name="CancelButton" Content="キャンセル" Width="80" Click="OnCancelClicked" HorizontalContentAlignment="Center"/>
 	</StackPanel>
   </Grid>
 </Window>

--- a/FLaunch2/Views/ImportWindow.axaml
+++ b/FLaunch2/Views/ImportWindow.axaml
@@ -14,10 +14,10 @@
         Title="インポート">
   <DockPanel Margin="12">
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
-      <Button Content="すべて選択" Command="{Binding SelectAllCommand}" />
-      <Button Content="すべて解除" Command="{Binding DeselectAllCommand}" />
-      <Button Content="インポート" Click="OnImportClicked" IsDefault="True" />
-      <Button Content="キャンセル" Click="OnCancelClicked" IsCancel="True" />
+      <Button Content="すべて選択" Command="{Binding SelectAllCommand}" HorizontalContentAlignment="Center" />
+      <Button Content="すべて解除" Command="{Binding DeselectAllCommand}" HorizontalContentAlignment="Center" />
+      <Button Content="インポート" Click="OnImportClicked" IsDefault="True" HorizontalContentAlignment="Center" />
+      <Button Content="キャンセル" Click="OnCancelClicked" IsCancel="True" HorizontalContentAlignment="Center" />
     </StackPanel>
     <ListBox ItemsSource="{Binding Items}" SelectionMode="Toggle">
       <ListBox.ItemTemplate>

--- a/FLaunch2/Views/ItemEditWindow.axaml
+++ b/FLaunch2/Views/ItemEditWindow.axaml
@@ -19,12 +19,12 @@
     <!-- 下部ボタン -->
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
                 HorizontalAlignment="Right" Margin="0,8,0,0" Spacing="8">
-      <Button Content="リンク解析" Command="{Binding ResolveLinkCommand}" />
+      <Button Content="リンク解析" Command="{Binding ResolveLinkCommand}" HorizontalContentAlignment="Center" />
       <Panel Width="80" /> <!-- スペーサー -->
       <Button Content="OK" Width="75" Command="{Binding OkCommand}"
-              CommandParameter="{Binding $parent[Window]}" />
+              CommandParameter="{Binding $parent[Window]}" HorizontalContentAlignment="Center" />
       <Button Content="キャンセル" Width="75" Command="{Binding CancelCommand}"
-              CommandParameter="{Binding $parent[Window]}" />
+              CommandParameter="{Binding $parent[Window]}" HorizontalContentAlignment="Center" />
     </StackPanel>
 
     <!-- フォーム本体 -->


### PR DESCRIPTION
すべてのウィンドウのボタンに HorizontalContentAlignment="Center" を追加し、テキストの中央揃えを適用しました。これによりUIの一貫性と視認性が向上します。 resolve #83